### PR TITLE
Update trace.py - parenthesis fix

### DIFF
--- a/snub/gui/tracks/trace.py
+++ b/snub/gui/tracks/trace.py
@@ -78,7 +78,7 @@ class TracePlot(Track):
         if data is not None:
             self.data = data
         else:
-            self.data = pickle.load(open(data_path), "rb")
+            self.data = pickle.load(open(data_path, "rb"))
 
         if initial_visible_traces is not None:
             self.visible_traces = set(initial_visible_traces)


### PR DESCRIPTION
Got the error below after adding some traceplots to my project. I [found](https://github.com/calebweinreb/SNUB/blob/main/snub/gui/tracks/trace.py#L81) that the "rb" argument is used by open() rather than pickle.load(). After patching this, things worked fine!

```
Traceback (most recent call last):
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\main.py", line 407, in open
    self.load_project(project_dir)
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\main.py", line 434, in load_project
    project_tab = ProjectTab(project_directory)
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\main.py", line 83, in __init__
    self.trackStack = TrackStack(config, self.selected_intervals)
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\stacks\track.py", line 49, in __init__
    track = HeadedTracePlot(config, **props)
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\tracks\trace.py", line 348, in __init__
    trace = TracePlot(config, **kwargs)
  File "C:\Users\rep359\Anaconda3\envs\snub\lib\site-packages\snub\gui\tracks\trace.py", line 81, in __init__
    self.data = pickle.load(open(data_path), "rb")
```